### PR TITLE
allow from .foo import * (relative) sf 3309660

### DIFF
--- a/src/epydoc/docparser.py
+++ b/src/epydoc/docparser.py
@@ -869,7 +869,13 @@ def process_from_import(line, parent_docs, prev_line_doc, lineno,
 
     # >>> from sys import *
     elif rhs == [(token.OP, '*')]:
-        src_name = parse_dotted_name(lhs)
+        # Allow relative imports in this case, as per PEP 328
+        # e.g. from .foo import *
+        if (lhs[0] == (token.OP, '.')):
+            src_name = parse_dotted_name(lhs,
+                parent_name=parent_docs[-1].canonical_name)
+        else:
+            src_name = parse_dotted_name(lhs)
         _process_fromstar_import(src_name, parent_docs)
 
     # >>> from os.path import join, split


### PR DESCRIPTION
patch from
https://sourceforge.net/support/tracker.php?aid=3309668

Tested on 3.0.1

A relative import like:
from .foo import *

is not parsed correctly.

| Source code parsing failed (but introspection was successful).
| Error: Error during parsing: invalid syntax
| -- Bad dotted name

With the attached patch it does parse correctly.

---

Note that general support for relative imports was added with
d38a5778a0817b0b968c5c5b632ece7fa7ccfad8 in 2007-03-10.
This is just a special case, that was ommited before.
