### PR TITLE
mouseout event issue - sf 3575546

### DIFF
--- a/src/epydoc/docwriter/html_colorize.py
+++ b/src/epydoc/docwriter/html_colorize.py
@@ -137,6 +137,12 @@ function kill_doclink(id) {
 }
 function auto_kill_doclink(ev) {
   if (!ev) var ev = window.event;
+  var tg = (window.event) ? ev.SrcElement : ev.target;
+  if (tg.nodeName != 'DIV') return;
+  var reltg = (ev.relatedTarget) ? ev.relatedTarget : ev.toElement;
+  while (reltg != tg && reltg.nodeName != 'BODY')
+    reltg = reltg.parentNode
+  if (reltg == tg) return;
   if (!this.contains(ev.toElement)) {
     var parent = document.getElementById(this.parentID);
     parent.removeChild(parent.childNodes.item(0));


### PR DESCRIPTION
patch from
https://sourceforge.net/support/tracker.php?aid=3575546
(Jacob Beck)

---

There is a 'bug' of sorts in epydoc's generated 'epydoc.js' file. Browsers implement the 'onmouseout' event in a strange way that results in any link clicking auto-killing the doclink when hovered. There is a fix for that described here:

http://www.quirksmode.org/js/events_mouse.html#mouseover

I've uploaded a patch file that implements the above technique, applying it to epydoc/docwriter/html_colorize.py appears to fix the issue in all browsers I tested.
